### PR TITLE
Add categorical syllogism Venn visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,3 +428,7 @@ Explore how you can use Copilot to help you:
 
 ## 🔎 Found an issue or have an idea for improvement?
 Help us make this template repository better by [letting us know and opening an issue!](/../../issues/new).
+
+## 📖 Proyecto adicional: Visualizador de silogismos
+
+En la carpeta `venn-syllogism` encontrarás un ejemplo básico para representar silogismos categóricos mediante un diagrama de Venn de tres conjuntos. Para ejecutarlo solo abre `venn-syllogism/src/index.html` en tu navegador favorito.

--- a/venn-syllogism/README.md
+++ b/venn-syllogism/README.md
@@ -1,0 +1,5 @@
+# Visualizador de Silogismos con Diagramas de Venn
+
+Esta aplicación sencilla muestra cómo representar algunos silogismos categóricos utilizando un diagrama de Venn de tres conjuntos.
+
+Abre `src/index.html` en un navegador web. Utiliza el selector para cambiar entre silogismos de ejemplo y observar cómo se resaltan los conjuntos implicados en la conclusión.

--- a/venn-syllogism/src/index.html
+++ b/venn-syllogism/src/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Visualizador de Silogismos</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Visualizador de Silogismos con Diagramas de Venn</h1>
+  <label for="syllogism">Selecciona un silogismo:</label>
+  <select id="syllogism">
+    <option value="AAA">Todo A es B; Todo B es C → Todo A es C</option>
+    <option value="EAC">Ningún A es B; Todo C es A → Ningún C es B</option>
+    <option value="IBO">Algún A es B; Ningún B es C → Algún A no es C</option>
+    <option value="ABO">Todo A es B; Algún B no es C → Algún A no es C</option>
+  </select>
+
+  <svg id="venn" width="500" height="400" viewBox="0 0 500 400"></svg>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/venn-syllogism/src/script.js
+++ b/venn-syllogism/src/script.js
@@ -1,0 +1,64 @@
+const svg = document.getElementById('venn');
+
+function createCircle(cx, cy, color, label) {
+  const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+  circle.setAttribute('cx', cx);
+  circle.setAttribute('cy', cy);
+  circle.setAttribute('r', 100);
+  circle.setAttribute('fill', color);
+  svg.appendChild(circle);
+
+  const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+  text.setAttribute('x', cx);
+  text.setAttribute('y', cy);
+  text.setAttribute('text-anchor', 'middle');
+  text.setAttribute('dominant-baseline', 'middle');
+  text.textContent = label;
+  svg.appendChild(text);
+
+  return circle;
+}
+
+const circles = {
+  A: createCircle(180, 220, 'red', 'A'),
+  B: createCircle(260, 220, 'green', 'B'),
+  C: createCircle(220, 120, 'blue', 'C')
+};
+
+function resetColors() {
+  circles.A.setAttribute('fill-opacity', 0.3);
+  circles.B.setAttribute('fill-opacity', 0.3);
+  circles.C.setAttribute('fill-opacity', 0.3);
+}
+
+function highlight(...names) {
+  resetColors();
+  names.forEach(name => {
+    if (circles[name]) {
+      circles[name].setAttribute('fill-opacity', 0.6);
+    }
+  });
+}
+
+function update() {
+  const val = document.getElementById('syllogism').value;
+  switch (val) {
+    case 'AAA':
+      highlight('A', 'C');
+      break;
+    case 'EAC':
+      highlight('C', 'B');
+      break;
+    case 'IBO':
+      highlight('A');
+      break;
+    case 'ABO':
+      highlight('A', 'B');
+      break;
+    default:
+      resetColors();
+  }
+}
+
+update();
+document.getElementById('syllogism').addEventListener('change', update);

--- a/venn-syllogism/src/styles.css
+++ b/venn-syllogism/src/styles.css
@@ -1,0 +1,14 @@
+body {
+    font-family: sans-serif;
+    text-align: center;
+}
+
+circle {
+    fill-opacity: 0.3;
+    stroke: black;
+    stroke-width: 2;
+}
+
+.hidden {
+    fill-opacity: 0.05;
+}


### PR DESCRIPTION
## Summary
- add `venn-syllogism` project to visualize categorical syllogisms with Venn diagrams
- document the new example in `README.md`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f6b9e6cdc83278890937a8479a683